### PR TITLE
fix: add task head creation in regressor

### DIFF
--- a/spaceai/models/predictors/multihead_regressor.py
+++ b/spaceai/models/predictors/multihead_regressor.py
@@ -13,6 +13,13 @@ class MultiHeadRegressor(DynamicModule):
         self.out_features = out_features
         self.heads = nn.ModuleDict()
 
+    def adaptation(self, experience):
+        """Aggiunge la testa per il task corrente se non esiste."""
+        task_label = self._get_single_task_label(experience.dataset)
+        key = str(task_label)
+        if key not in self.heads:
+            self.heads[key] = nn.Linear(self.in_features, self.out_features)
+
     def _get_single_task_label(self, ds):
         tl = ds.targets_task_labels
         if isinstance(tl, torch.Tensor):

--- a/tests/test_multihead_regressor.py
+++ b/tests/test_multihead_regressor.py
@@ -1,0 +1,34 @@
+import torch
+from types import SimpleNamespace
+
+from spaceai.models.predictors.multihead_regressor import MultiHeadRegressor
+
+
+class _DummyDataset(torch.utils.data.Dataset):
+    def __init__(self, n_samples: int, in_features: int, task_label: int):
+        self.x = torch.randn(n_samples, in_features)
+        self.y = torch.randn(n_samples, 1)
+        self.targets_task_labels = torch.full((n_samples,), task_label)
+
+    def __len__(self):
+        return len(self.x)
+
+    def __getitem__(self, idx):
+        return self.x[idx], self.y[idx]
+
+
+def test_adaptation_adds_new_head():
+    reg = MultiHeadRegressor(in_features=3, out_features=1)
+
+    ds0 = _DummyDataset(5, 3, task_label=0)
+    exp0 = SimpleNamespace(dataset=ds0)
+    reg.adaptation(exp0)
+    assert "0" in reg.heads
+
+    ds1 = _DummyDataset(5, 3, task_label=1)
+    exp1 = SimpleNamespace(dataset=ds1)
+    reg.adaptation(exp1)
+    assert "1" in reg.heads
+
+    out = reg(torch.randn(2, 3), torch.tensor([1]))
+    assert out.shape == (2, 1)


### PR DESCRIPTION
## Summary
- add adaptation step to MultiHeadRegressor to create heads per task
- test MultiHeadRegressor head creation

## Testing
- `PYTHONPATH=. pytest -q -c /tmp/pytest.cfg tests/test_multihead_regressor.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'spaceai.benchmarks')*


------
https://chatgpt.com/codex/tasks/task_b_68acd3987c308333bad87e158addc65d