### PR TITLE
Refactor PNN evaluation and tidy debugging prints

### DIFF
--- a/spaceai/models/predictors/pnn_lstm.py
+++ b/spaceai/models/predictors/pnn_lstm.py
@@ -129,10 +129,7 @@ class PNNColumn(nn.Module):
             param.requires_grad = False
 
     def forward(self, x):
-        print(np.array(x).shape)
         prev_xs, last_x = x[:-1], x[-1]
-        print(np.array(prev_xs).shape)
-        print(prev_xs)
         hs = self.adapter(prev_xs)
         hs += self.itoh(last_x)
         return hs
@@ -186,7 +183,6 @@ class PNNLayer(MultiTaskModule):
         self.train_adaptation(experience.dataset)
 
     def train_adaptation(self, dataset: AvalancheDataset):
-        print("train_adaptation")
         # ⚠️ RIMUOVI questa riga che causava l’errore:
         # super().train_adaptation(dataset)
         task_labels_raw = dataset.targets_task_labels
@@ -231,10 +227,8 @@ class PNNLayer(MultiTaskModule):
         :return:
         """
         col_idx = self.task_to_module_idx[task_label]
-        print(f"col_idx: {col_idx}")
         hs = []
         for ii in range(col_idx + 1):
-            #print(self.columns)
             hs.append(self.columns[ii](x[: ii + 1]))
         return hs
 
@@ -298,16 +292,13 @@ class PNN(MultiTaskModule):
         self.regressor.adaptation(experience)
 
     def forward_single_task(self, x, task_label):
-        print("forward single task")
         #x = x.contiguous().view(x.size(0), self.in_features)
 
         num_columns = self.layers[0].num_columns
         col_idx = self.layers[-1].task_to_module_idx[task_label]
-        print(col_idx)
 
         x = [x for _ in range(num_columns)]
         for lay in self.layers:
-            print(f"lay: {lay}")
             x = [F.relu(el) for el in lay.forward_single_task(x, task_label)]
         # ⬇️ usa la regressor head
         return self.regressor.forward_single_task(x[col_idx], task_label)


### PR DESCRIPTION
## Summary
- drop verbose debug prints from PNN LSTM and CLTrainer
- rework NASA `run_pnn` evaluation using `CLTrainer.evaluate_experience`
- update CLTrainer evaluation to accept raw subsets

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'spaceai.benchmarks')*

------
https://chatgpt.com/codex/tasks/task_b_68ace0adb2548333ac6c90ebdd5e4aa3