### PR TITLE
Remove leftover prints and add training progress bar

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,1 +1,1 @@
-print("Build completed.")
+"""Build script placeholder."""

--- a/spaceai/data/nasa.py
+++ b/spaceai/data/nasa.py
@@ -165,7 +165,6 @@ class NASA(AnomalyDataset):
             )
 
         self.data, self.anomalies = self.load_and_preprocess()
-        print(f"self.data: {self.data.shape}")
 
     def __getitem__(self, index: int) -> Union[
         Tuple[torch.Tensor, torch.Tensor],

--- a/spaceai/models/predictors/lstm.py
+++ b/spaceai/models/predictors/lstm.py
@@ -57,7 +57,6 @@ class LSTM(SequenceModel):
 
     def __call__(self, input):
         pred = super().__call__(input)
-        print(pred)
         if self.reduce_out is None:
             return pred
         elif self.reduce_out == "mean":


### PR DESCRIPTION
## Summary
- stop helper reports from printing and adjust CLTrainer training loop to use a progress bar with loss
- drop debug prints in sequence model, LSTM wrapper, and NASA dataset
- replace build script print with placeholder docstring

## Testing
- `PYTHONPATH=. pytest` *(fails: AttributeError: partially initialized module 'torchvision' has no attribute 'extension')*


------
https://chatgpt.com/codex/tasks/task_b_68ae3db5c6388333beb77d442d5584dd