### PR TITLE
Align evaluation with training in CLTrainer

### DIFF
--- a/spaceai/benchmark/utils.py
+++ b/spaceai/benchmark/utils.py
@@ -87,11 +87,13 @@ class CLTrainer:
             collate_fn=seq_collate_fn(n_inputs=2, mode="batch"),
         )
         total, n = 0.0, 0
-        for x, y in dl:
-            x = x.to(self.device); y = y.to(self.device)
-            out = self.model(x, task)
-            loss = self.criterion(out.squeeze(-1), y.squeeze(-1))
-            bs = x.size(0)
+        for inputs, targets in dl:
+            inputs = inputs.to(self.device)
+            targets = targets.to(self.device)
+            outputs = self.model(inputs, task)
+            outputs, targets = self._apply_washout(outputs, targets)
+            loss = self.criterion(outputs, targets)
+            bs = inputs.size(0)
             total += loss.item() * bs
             n += bs
         return total / max(n, 1)


### PR DESCRIPTION
## Summary
- mirror training preprocessing in evaluation by applying washout and avoiding unnecessary squeezes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'avalanche')*

------
https://chatgpt.com/codex/tasks/task_b_68af075da30c8333acba743db8f80bd0